### PR TITLE
docs: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,9 @@
 </h1>
 
 <p align='center'>
-  <a href='https://www.npmjs.com/package/react-player'>
-    <img src='https://img.shields.io/npm/v/react-player.svg' alt='Latest npm version'>
-  </a>
-  <a href='https://codecov.io/gh/CookPete/react-player'>
-    <img src='https://img.shields.io/codecov/c/github/cookpete/react-player.svg' alt='Test Coverage'>
-  </a>
-  <a href='https://www.patreon.com/cookpete'>
-    <img src='https://img.shields.io/badge/sponsor-patreon-fa6854.svg' alt='Become a sponsor on Patreon'>
-  </a>
+  <a href='https://www.npmjs.com/package/react-player'><img src='https://img.shields.io/npm/v/react-player.svg' alt='Latest npm version'></a>
+  <a href='https://codecov.io/gh/CookPete/react-player'><img src='https://img.shields.io/codecov/c/github/cookpete/react-player.svg' alt='Test Coverage'></a>
+  <a href='https://www.patreon.com/cookpete'><img src='https://img.shields.io/badge/sponsor-patreon-fa6854.svg' alt='Become a sponsor on Patreon'></a>
 </p>
 
 <p align='center'>


### PR DESCRIPTION
Remove unwanted underline between shield badges.

Possibly a result of how line endings are handled in github flavored markdown